### PR TITLE
Add option to parse input as HTML

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,6 +91,15 @@ module.exports = function(grunt) {
           filepath: true,
           stylesheet: 'test/fixtures/template_filepath.xsl'
         }
+      },
+      html: {
+        files: {
+          'tmp/html.html': ['test/fixtures/html.html']
+        },
+        options: {
+          html: true,
+          stylesheet: 'test/fixtures/html.xsl'
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Type: `Boolean`
 
 Pass the grunt filepath as stringparam to the XSLT.
 
+
+#### options.html
+Type: `Boolean`
+
+The input document is(are) an HTML file(s).
+
+
 ### Usage Examples
 
 #### Single file
@@ -247,6 +254,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 ## Release History
 
+ * 2014-11-10   v0.4.2   Add option to parse input as HTML.
  * 2014-10-05   v0.4.1   Add option for passing the grunt filepath as stringparam.
  * 2014-04-21   v0.4.0   Add option to use XIncludestyle.
  * 2013-11-16   v0.3.0   Enable processing using the XInclude specification.

--- a/tasks/xsltproc.js
+++ b/tasks/xsltproc.js
@@ -73,6 +73,11 @@ module.exports = function(grunt) {
           args.push('--novalid');
         }
 
+        // the input document is(are) an HTML file(s)
+        if (options.html) {
+          args.push('--html');
+        }
+
         // Add file paths to the args
         args.push('--output', file.dest);
         args.push(options.stylesheet);

--- a/test/expected/html.html
+++ b/test/expected/html.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>html</title>
+</head>
+<body>
+  <p>html</p>
+  <hr>
+  <img src="foo">
+</body>
+</html>

--- a/test/fixtures/html.html
+++ b/test/fixtures/html.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>html</title>
+</head>
+<body>
+  <p>html</p>
+  <hr>
+  <img src="foo">
+</body>
+</html>

--- a/test/fixtures/html.xsl
+++ b/test/fixtures/html.xsl
@@ -1,0 +1,9 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" omit-xml-declaration="yes" encoding="utf-8" indent="yes" media-type="text/html" />
+
+  <xsl:template match="node() | @*" priority="-10">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template> 
+</xsl:stylesheet>

--- a/test/xsltproc_test.js
+++ b/test/xsltproc_test.js
@@ -70,6 +70,17 @@ exports.xsltproc = {
     test.equal(result, expected, 'should enable the use of filepath');
 
     test.done();
+  },
+  html: function(test) {
+    'use strict';
+    test.expect(1);
+
+    var result = grunt.file.read('tmp/html.html');
+    var expected = grunt.file.read('test/expected/html.html');
+    test.equal(result, expected, 'should enable the use of html');
+
+    test.done();
   }
+  
 };
 


### PR DESCRIPTION
To use HTML als Input, xsltproc needs the --html flag.
