### PR TITLE
Cannot invoke xsltproc without specifying a stylesheet

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,6 +100,14 @@ module.exports = function(grunt) {
           html: true,
           stylesheet: 'test/fixtures/html.xsl'
         }
+      },
+      inline: {
+        options: {
+          stylesheet: null
+        },
+        files: {
+          'tmp/inline.html': ['test/fixtures/data/albums.xml']
+        }
       }
     },
 

--- a/tasks/xsltproc.js
+++ b/tasks/xsltproc.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
     var options = this.options();
 
     // Check for the stylesheet file
-    if ( !options.stylesheet || !grunt.file.exists(options.stylesheet) ) {
+    if ( options.stylesheet && !grunt.file.exists(options.stylesheet) ) {
       grunt.log.error('Stylesheet file "' + options.stylesheet + '" not found.');
       return false;
     }
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
           args.push('--stringparam');
           args.push(key, value);
         });
-        
+
         //  grunt filepath as stringparam
         if (options.filepath) {
           args.push('--stringparam');
@@ -80,7 +80,13 @@ module.exports = function(grunt) {
 
         // Add file paths to the args
         args.push('--output', file.dest);
-        args.push(options.stylesheet);
+
+        // If a stylesheet has been specified, use it
+        //   otherwise fallback to linked stylesheets
+        if (options.stylesheet) {
+          args.push(options.stylesheet);
+        }
+
         args.push(filepath);
       });
 

--- a/test/expected/simple-list.html
+++ b/test/expected/simple-list.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>My Albums</title>
+</head>
+<body>
+<h1>My Albums</h1>
+<ul class="albums">
+<li class="album">The Jimi Hendrix Experience - Are You Experienced</li>
+<li class="album">The White Stripes - White Blood Cells</li>
+<li class="album">The Black Keys - Thickfreakness</li>
+</ul>
+</body>
+</html>

--- a/test/fixtures/data/albums.xml
+++ b/test/fixtures/data/albums.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<?xml-stylesheet type="text/xsl" href="../simple-list.xsl" ?>
 <catalogue title="My Albums">
   <album id="1">
     <title>Are You Experienced</title>

--- a/test/fixtures/simple-list.xsl
+++ b/test/fixtures/simple-list.xsl
@@ -1,0 +1,25 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="html" omit-xml-declaration="yes" encoding="utf-8" indent="yes" media-type="text/html" />
+
+  <xsl:template match="/catalogue">
+    <html>
+    <head>
+      <title><xsl:value-of select="@title" /></title>
+    </head>
+    <body>
+      <h1><xsl:value-of select="@title" /></h1>
+      <ul class="albums">
+        <xsl:apply-templates select="./album" />
+      </ul>
+    </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="album">
+    <li class="album">
+      <xsl:apply-templates select="./artist" />
+      <xsl:text> - </xsl:text>
+      <xsl:apply-templates select="./title" />
+    </li>
+  </xsl:template>
+</xsl:stylesheet>

--- a/test/xsltproc_test.js
+++ b/test/xsltproc_test.js
@@ -80,7 +80,15 @@ exports.xsltproc = {
     test.equal(result, expected, 'should enable the use of html');
 
     test.done();
-  }
-  
-};
+  },
+  inline: function(test) {
+    'use strict';
+    test.expect(1);
 
+    var result = grunt.file.read('tmp/inline.html');
+    var expected = grunt.file.read('test/expected/simple-list.html');
+    test.equal(result, expected, 'should use inline stylesheet if none specified in options');
+
+    test.done();
+  }
+};


### PR DESCRIPTION
Currently, grunt-xsltproc requires a stylesheet to be specified in the options. This means that xsltproc is always called in the form:

    xsltproc somestylesheet somexmldoc

which overrides any stylesheets defined in the XML document with, for example.

<?xml-stylesheet type="text/xsl" href="mystylesheet.xsl" ?>

There doesn't seem to be a way to call xsltproc as:

    xsltproc somexmldoc

It looks to me as if this could be fixed simply with:

    17c17
    <     if ( !options.stylesheet || !grunt.file.exists(options.stylesheet) ) {
    ---
    >     if ( options.stylesheet && !grunt.file.exists(options.stylesheet) ) {
    83c83,85
    <         args.push(options.stylesheet);
    ---
    >         if (options.stylesheet) {
    >         	args.push(options.stylesheet);
    >         }
